### PR TITLE
Fix logo cutoff

### DIFF
--- a/src/components/Landing/Landing.Styles.css
+++ b/src/components/Landing/Landing.Styles.css
@@ -89,7 +89,7 @@
 }
 
 .container {
-    margin-top: 14px;
+    margin-top: 50px;
     padding-bottom: 47px;
     -webkit-align-self: center;
     -ms-flex-item-align: center;


### PR DESCRIPTION
Fixes [ui-kit #2](https://github.com/Rug-Zombie/rug-zombie-uikit/issues/2)

<img width="319" alt="Screen Shot 2021-10-20 at 9 31 32 PM" src="https://user-images.githubusercontent.com/37122448/138202583-accaf269-8699-4ac1-8938-cf18f240a7b0.png">

